### PR TITLE
Accept a function for URL option.

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -15,10 +15,15 @@ exports.sourceNodes = async (nodeActions, configOptions) => {
 	const method =
 		configOptions.method === undefined ? "get" : configOptions.method;
 
+	const url =
+		configOptions.url instanceof Function
+			? await configOptions.url()
+			: configOptions.url;
+
 	axios({
 		httpsAgent: new https.Agent({ rejectUnauthorized: false }),
 		method: method.toLowerCase(),
-		url: configOptions.url,
+		url: url,
 		responseType: configOptions.saveTo ? "stream" : undefined,
 		...configOptions.axiosConfig,
 	}).then(res => {


### PR DESCRIPTION
Sometimes the source URL is not always known ahead of time within the `gatsby-config.js` file. 

In my use-case (and I'm sure others too) I needed to perform an async query to an API in order to get that URL.

In this example, the URL is queried from a Prismic CMS that has the CSV file hosted on a CDN. In other words, without querying, it's impossible for us to know what the URL should be. With that in mind, an async method is needed as Gatsby does not allow async operations in the file itself (reliably).

```
{
  resolve: `gatsby-source-fetch`
  options: {
    name: `brands`,
    type: `brands`,
    url: async () => {
      const api = await Prismic.getApi("https://my-website.prismic.io/api/v2")
      const brands = await api.getSingle("brands")
      const { url } = brands.data.summary
      return url
    },
    method: `get`,
    axiosConfig: {
      headers: { Accept: "text/csv" },
    },
    saveTo: `${__dirname}/src/data/brands-summary.csv`,
    createNodes: false,
  },
},
```

At the moment, your plugin only allows a string to be passed for the URL...but in this PR, we can pass a function (as shown above). A string is still accepted as valid if the URL option is not a function.